### PR TITLE
提取多个缩略图

### DIFF
--- a/app/article/article.admincp.php
+++ b/app/article/article.admincp.php
@@ -832,26 +832,45 @@ class articleAdmincp{
             return $description;
         }
     }
-    public function set_pic($picurl,$aid,$key='b'){
-        $uri = parse_url(iCMS_FS_URL);
-        if (stripos($picurl,$uri['host']) !== false){
-            $pic = iFS::fp($picurl,'-http');
-            list($width, $height, $type, $attr) = @getimagesize(iFS::fp($pic,'+iPATH'));
-
-            $picdata  = article::value('picdata',$aid);
-            $picArray = filesApp::get_picdata($picdata);
-            $picdata  = filesAdmincp::picdata($picArray,array($key=>array('w'=>$width,'h'=>$height)));
-
-            $field = 'pic';
-            if($key=='b'){
-                $haspic = 1;
-            }else{
-                $field = $key.'pic';
-            }
-
-            article::update(compact('haspic',$field,'picdata'),array('id'=>$aid));
-            files::set_map(self::$appid,$aid,$pic,'path');
-        }
+	public function set_pic($picurl,$aid,$key='b'){
+    	$uri = parse_url(iCMS_FS_URL);
+    	$pics = array();
+    	if (is_array($picurl))
+    	{
+    		$pics = $picurl;
+    		$picurl = $picurl[0];
+    	}
+    
+    	if (stripos($picurl,$uri['host']) !== false){
+    		$pic = iFS::fp($picurl,'-http');
+    		list($width, $height, $type, $attr) = @getimagesize(iFS::fp($pic,'+iPATH'));
+    
+    		$picdata  = article::value('picdata',$aid);
+    		$picArray = filesApp::get_picdata($picdata);
+    		$picdata  = filesAdmincp::picdata($picArray,array($key=>array('w'=>$width,'h'=>$height)));
+    
+    		$field = 'pic';
+    		if($key=='b'){
+    			$haspic = 1;
+    		}else{
+    			$field = $key.'pic';
+    		}
+    
+    		article::update(compact('haspic',$field,'picdata'),array('id'=>$aid));
+    		files::set_map(self::$appid,$aid,$pic,'path');
+    	}
+    	 
+    	if (count($pics)>=3)
+    	{
+    		$mpic = $pics[1];
+    		$mpic = iFS::fp($mpic,'-http');
+    		$spic = $pics[2];
+    		$spic = iFS::fp($spic,'-http');
+    
+    		article::update(compact('mpic','spic','picdata'),array('id'=>$aid));
+    		files::set_map(self::$appid,$aid,$mpic,'path');
+    		files::set_map(self::$appid,$aid,$spic,'path');
+    	}
     }
 
     public function check_pic($body,$aid=0){

--- a/app/files/files.admincp.php
+++ b/app/files/files.admincp.php
@@ -414,6 +414,7 @@ class filesAdmincp{
         $array   = files::preg_img($content,$match);
         $uri     = parse_url(iCMS_FS_URL);
         $fArray  = array();
+        $img_array = array();
         foreach ($array as $key => $value) {
             $value = trim($value);
             if (stripos($value,$uri['host']) === false){
@@ -441,13 +442,15 @@ class filesAdmincp{
                     $fArray[$key] = '';
                 }
             }
-            if($remote==="autopic" && $key==0){
-                return $value;
-            }
+             $img_array[] = $value;
         }
         if($remote==="autopic" && empty($array)){
             return;
         }
+        if($remote==="autopic"){
+        	return $img_array;
+        }
+        
         if($array && $fArray){
             krsort($array);
             krsort($fArray);


### PR DESCRIPTION
2017年6月6日 
   如果没有手动提交缩略图片，且自动提取
		如果图片少于3张，只提取第一张，当图片数量大于等于3张的时候才提取第二张和第三张
		使用官方提供的模板语言调用
如
 ```
<!--{if $article_list.mpic.url}--><img src="<!--{$article_list.mpic.url}-->"/> <!--{/if}-->
<!--{if $article_list.spic.url}--> <img src="<!--{$article_list.spic.url}-->"/> <!--{/if}-->
```